### PR TITLE
Fix issues, improve performance, and clean up several renderers

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/client/model/ModelMyrmexRoyal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/model/ModelMyrmexRoyal.java
@@ -1,11 +1,11 @@
 package com.github.alexthe666.iceandfire.client.model;
 
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexRoyal;
+
 import net.ilexiconn.llibrary.client.model.ModelAnimator;
 import net.ilexiconn.llibrary.client.model.tools.AdvancedModelRenderer;
 import net.ilexiconn.llibrary.server.animation.IAnimatedEntity;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 public class ModelMyrmexRoyal extends ModelMyrmexBase {
@@ -255,13 +255,7 @@ public class ModelMyrmexRoyal extends ModelMyrmexBase {
     public void renderAdult(Entity entity, float f, float f1, float f2, float f3, float f4, float f5) {
         animate((IAnimatedEntity) entity, f, f1, f2, f3, f4, f5);
         setRotationAngles(f, f1, f2, f3, f4, f5, entity);
-        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-        GlStateManager.enableNormalize();
-        GlStateManager.enableBlend();
-        GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
         this.Body2.render(f5);
-        GlStateManager.disableBlend();
-        GlStateManager.disableNormalize();
     }
 
     public void animate(IAnimatedEntity entity, float f, float f1, float f2, float f3, float f4, float f5) {

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
@@ -22,16 +22,13 @@ public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 	@Override
 	public void doRender(EntityDreadLichSkull entity, double x, double y, double z, float entityYaw, float partialTicks) {
 		GlStateManager.pushMatrix();
+
 		GlStateManager.translate(x, y, z);
-		GlStateManager.pushMatrix();
 		GlStateManager.scale(1.0F, -1.0F, 1.0F);
 		GlStateManager.rotate(interpolateRotation(entity.prevRotationYaw, entity.rotationYaw, partialTicks) - 180.0F, 0.0F, 1.0F, 0.0F);
 
 		GlStateManager.disableCull();
 		GlStateManager.enableRescaleNormal();
-		GlStateManager.enableAlpha();
-		GlStateManager.enableBlend();
-		GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
 		GlStateManager.disableLighting();
 		if (this.renderOutlines) {
 			GlStateManager.enableColorMaterial();
@@ -43,18 +40,15 @@ public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 0.0F);
 		MODEL.render(entity, 0.0F, 0.0F, entity.ticksExisted + partialTicks, 0.0F, 0.0F, 0.0625F);
 
-		GlStateManager.enableLighting();
-		GlStateManager.disableBlend();
+		GlStateManager.enableCull();
+		GlStateManager.disableRescaleNormal();
 		GlStateManager.enableLighting();
 		if (this.renderOutlines) {
-			GlStateManager.disableOutlineMode();
 			GlStateManager.disableColorMaterial();
+			GlStateManager.disableOutlineMode();
 		}
 
 		GlStateManager.popMatrix();
-		GlStateManager.popMatrix();
-
-		super.doRender(entity, x, y, z, entityYaw, partialTicks);
 	}
 
 	private static float interpolateRotation(float prevYawOffset, float yawOffset, float partialTicks) {

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 
 public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 
@@ -24,7 +25,7 @@ public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 		GlStateManager.translate(x, y, z);
 		GlStateManager.pushMatrix();
 		GlStateManager.scale(1.0F, -1.0F, 1.0F);
-		GlStateManager.rotate(interpolateValue(entity.prevRotationYaw, entity.rotationYaw, partialTicks) - 180.0F, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(interpolateRotation(entity.prevRotationYaw, entity.rotationYaw, partialTicks) - 180.0F, 0.0F, 1.0F, 0.0F);
 
 		GlStateManager.disableCull();
 		GlStateManager.enableRescaleNormal();
@@ -56,8 +57,11 @@ public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 		super.doRender(entity, x, y, z, entityYaw, partialTicks);
 	}
 
-	private static float interpolateValue(float start, float end, float pct) {
-		return start + (end - start) * pct;
+	private static float interpolateRotation(float prevYawOffset, float yawOffset, float partialTicks) {
+		float f = yawOffset - prevYawOffset;
+		int i = MathHelper.floor(f);
+		f = ((((i % 360) + 540) % 360) - 180) + (f - i);
+		return prevYawOffset + partialTicks * f;
 	}
 
 	@Override

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
@@ -2,66 +2,67 @@ package com.github.alexthe666.iceandfire.client.render.entity;
 
 import com.github.alexthe666.iceandfire.client.model.ModelDreadLichSkull;
 import com.github.alexthe666.iceandfire.entity.projectile.EntityDreadLichSkull;
+
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
-
 public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
-    public static final ResourceLocation TEXTURE = new ResourceLocation("iceandfire:textures/models/dread/dread_lich_skull.png");
-    private static final ModelDreadLichSkull MODEL_SPIRIT = new ModelDreadLichSkull();
 
-    public RenderDreadLichSkull(RenderManager manager) {
-        super(manager);
-    }
+	public static final ModelDreadLichSkull MODEL = new ModelDreadLichSkull();
+	public static final ResourceLocation TEXTURE = new ResourceLocation("iceandfire:textures/models/dread/dread_lich_skull.png");
 
-    public void doRender(EntityDreadLichSkull entity, double x, double y, double z, float entityYaw, float partialTicks) {
-        GlStateManager.pushMatrix();
-        GlStateManager.disableCull();
-        GlStateManager.translate((float) x, (float) y, (float) z);
-        float f = 0.0625F;
-        GlStateManager.enableRescaleNormal();
-        GlStateManager.enableAlpha();
-        this.bindEntityTexture(entity);
+	public RenderDreadLichSkull(RenderManager manager) {
+		super(manager);
+	}
 
-        if (this.renderOutlines) {
-            GlStateManager.enableColorMaterial();
-            GlStateManager.enableOutlineMode(this.getTeamColor(entity));
-        }
+	@Override
+	public void doRender(EntityDreadLichSkull entity, double x, double y, double z, float entityYaw, float partialTicks) {
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(x, y, z);
+		GlStateManager.pushMatrix();
+		GlStateManager.scale(1.0F, -1.0F, 1.0F);
+		GlStateManager.rotate(interpolateValue(entity.prevRotationYaw, entity.rotationYaw, partialTicks) - 180.0F, 0.0F, 1.0F, 0.0F);
 
-        GlStateManager.pushMatrix();
-        GlStateManager.scale(1.0F, -1.0F, 1.0F);
-        GlStateManager.enableBlend();
-        GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-        GlStateManager.disableLighting();
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 0.0F);
-        float yaw = entity.prevRotationYaw + (entity.rotationYaw - entity.prevRotationYaw) * partialTicks;
-        GlStateManager.translate(0F, 0.0F, 0F);
-        GlStateManager.rotate(yaw - 180, 0.0F, 1.0F, 0.0F);
-        new ModelDreadLichSkull().render(entity, 0, 0, partialTicks, 0, 0, 0.0625F);
-        GlStateManager.enableLighting();
-        GlStateManager.disableBlend();
-        GlStateManager.popMatrix();
-        if (this.renderOutlines) {
-            GlStateManager.disableOutlineMode();
-            GlStateManager.disableColorMaterial();
-        }
+		GlStateManager.disableCull();
+		GlStateManager.enableRescaleNormal();
+		GlStateManager.enableAlpha();
+		GlStateManager.enableBlend();
+		GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+		GlStateManager.disableLighting();
+		if (this.renderOutlines) {
+			GlStateManager.enableColorMaterial();
+			GlStateManager.enableOutlineMode(this.getTeamColor(entity));
+		}
 
-        GlStateManager.enableLighting();
-        GlStateManager.popMatrix();
-        super.doRender(entity, x, y, z, entityYaw, partialTicks);
-    }
+		this.bindEntityTexture(entity);
 
-    private float interpolateValue(float start, float end, float pct) {
-        return start + (end - start) * pct;
-    }
+		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 0.0F);
+		new ModelDreadLichSkull().render(entity, 0.0F, 0.0F, entity.ticksExisted + partialTicks, 0.0F, 0.0F, 0.0625F);
 
-    @Nullable
-    @Override
-    protected ResourceLocation getEntityTexture(EntityDreadLichSkull entity) {
-        return TEXTURE;
-    }
+		GlStateManager.enableLighting();
+		GlStateManager.disableBlend();
+		GlStateManager.enableLighting();
+		if (this.renderOutlines) {
+			GlStateManager.disableOutlineMode();
+			GlStateManager.disableColorMaterial();
+		}
+
+		GlStateManager.popMatrix();
+		GlStateManager.popMatrix();
+
+		super.doRender(entity, x, y, z, entityYaw, partialTicks);
+	}
+
+	private static float interpolateValue(float start, float end, float pct) {
+		return start + (end - start) * pct;
+	}
+
+	@Override
+	protected ResourceLocation getEntityTexture(EntityDreadLichSkull entity) {
+		return TEXTURE;
+	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDreadLichSkull.java
@@ -40,7 +40,7 @@ public class RenderDreadLichSkull extends Render<EntityDreadLichSkull> {
 		this.bindEntityTexture(entity);
 
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 0.0F);
-		new ModelDreadLichSkull().render(entity, 0.0F, 0.0F, entity.ticksExisted + partialTicks, 0.0F, 0.0F, 0.0625F);
+		MODEL.render(entity, 0.0F, 0.0F, entity.ticksExisted + partialTicks, 0.0F, 0.0F, 0.0625F);
 
 		GlStateManager.enableLighting();
 		GlStateManager.disableBlend();

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
@@ -1,83 +1,70 @@
 package com.github.alexthe666.iceandfire.client.render.entity;
 
+import org.lwjgl.opengl.GL11;
+
 import com.github.alexthe666.iceandfire.client.model.ModelGhost;
 import com.github.alexthe666.iceandfire.entity.EntityGhost;
+
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderLiving;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
-import org.lwjgl.opengl.GL11;
 
 public class RenderGhost extends RenderLiving<EntityGhost> {
 
-    public static final ResourceLocation TEXTURE_0 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_white.png");
-    public static final ResourceLocation TEXTURE_1 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_blue.png");
-    public static final ResourceLocation TEXTURE_2 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_green.png");
-    public static final ResourceLocation TEXTURE_SHOPPING_LIST = new ResourceLocation("iceandfire:textures/models/ghost/haunted_shopping_list.png");
+	public static final ModelGhost MODEL = new ModelGhost(0.0F);
+	public static final ResourceLocation TEXTURE_0 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_white.png");
+	public static final ResourceLocation TEXTURE_1 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_blue.png");
+	public static final ResourceLocation TEXTURE_2 = new ResourceLocation("iceandfire:textures/models/ghost/ghost_green.png");
+	public static final ResourceLocation TEXTURE_SHOPPING_LIST = new ResourceLocation("iceandfire:textures/models/ghost/haunted_shopping_list.png");
 
-    public RenderGhost(RenderManager renderManager) {
-        super(renderManager, new ModelGhost(0.0F), 0.55F);
-        preRenderProfileGhostClean();
-    }
+	public RenderGhost(RenderManager renderManager) {
+		super(renderManager, MODEL, 0.55F);
+		preRenderProfileGhostClean();
+	}
 
-    public static ResourceLocation getGhostOverlayForType(int ghost) {
-        switch (ghost) {
-            case 1:
-                return TEXTURE_1;
-            case 2:
-                return TEXTURE_2;
-            case -1:
-                return TEXTURE_SHOPPING_LIST;
-            default:
-                return TEXTURE_0;
-        }
-    }
+	public void preRenderProfileGhostApply(EntityGhost entity, float partialTicks) {
+		float alphaForRender = getAlphaForRender(entity, partialTicks);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, alphaForRender);
+		GlStateManager.depthMask(false);
+		GlStateManager.enableBlend();
+		GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.001F);
+	}
 
-    @Override
-    protected float getDeathMaxRotation(EntityGhost ghost) {
-        return 0.0F;
-    }
+	public void preRenderProfileGhostClean() {
+		GlStateManager.disableBlend();
+		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
+		GlStateManager.depthMask(true);
+	}
 
-    public void preRenderProfileGhostApply(EntityGhost entityIn, float partialTicks) {
-        float alphaForRender = getAlphaForRender(entityIn, partialTicks);
-        GlStateManager.color(1.0F, 1.0F, 1.0F, alphaForRender);
-        GlStateManager.depthMask(false);
-        GlStateManager.enableBlend();
-        GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-        GlStateManager.alphaFunc(GL11.GL_GREATER, 0.001F);
-    }
+	private float getAlphaForRender(EntityGhost entity, float partialTicks) {
+		if (entity.isDaytimeMode()) {
+			return MathHelper.clamp((101 - Math.min(entity.getDaytimeCounter(), 100)) / 100.0F, 0.0F, 1.0F);
+		}
+		return MathHelper.clamp((MathHelper.sin((entity.ticksExisted + partialTicks) * 0.1F) + 1.0F) * 0.5F + 0.1F, 0.0F, 1.0F);
+	}
 
-    public void preRenderProfileGhostClean() {
-        GlStateManager.disableBlend();
-        GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
-        GlStateManager.depthMask(true);
-    }
+	@Override
+	public void preRenderCallback(EntityGhost entitylivingbaseIn, float partialTickTime) {
+		this.shadowSize = 0.0F;
+		preRenderProfileGhostApply(entitylivingbaseIn, partialTickTime);
+	}
 
-    public float getAlphaForRender(EntityGhost entityIn, float partialTicks) {
-        if (entityIn.isDaytimeMode()) {
-            return MathHelper.clamp((101 - Math.min(entityIn.getDaytimeCounter(), 100)) / 100F, 0, 1);
-        }
-        return MathHelper.clamp((MathHelper.sin((entityIn.ticksExisted + partialTicks) * 0.1F) + 1F) * 0.5F + 0.1F, 0F, 1F);
-    }
+	@Override
+	protected ResourceLocation getEntityTexture(EntityGhost entity) {
+		switch (entity.getColor()) {
+			default: return TEXTURE_0;
+			case 1: return TEXTURE_1;
+			case 2: return TEXTURE_2;
+			case -1: return TEXTURE_SHOPPING_LIST;
+		}
+	}
 
-    @Override
-    public void preRenderCallback(EntityGhost EntityLivingIn, float partialTickTime) {
-        this.shadowSize = 0;
-        preRenderProfileGhostApply(EntityLivingIn, partialTickTime);
-    }
+	@Override
+	protected float getDeathMaxRotation(EntityGhost entityLivingBaseIn) {
+		return 0.0F;
+	}
 
-    @Override
-    public ResourceLocation getEntityTexture(EntityGhost ghost) {
-        switch (ghost.getColor()) {
-            case 1:
-                return TEXTURE_1;
-            case 2:
-                return TEXTURE_2;
-            case -1:
-                return TEXTURE_SHOPPING_LIST;
-            default:
-                return TEXTURE_0;
-        }
-    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
@@ -26,14 +26,11 @@ public class RenderGhost extends RenderLiving<EntityGhost> {
 	protected void renderModel(EntityGhost entitylivingbaseIn, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch,
 			float scaleFactor) {
 		GlStateManager.disableAlpha();
-		GlStateManager.enableBlend();
-		GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
 
 		GlStateManager.color(1.0F, 1.0F, 1.0F, this.getAlphaForRender(entitylivingbaseIn, scaleFactor));
 		super.renderModel(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor);
 
 		GlStateManager.enableAlpha();
-		GlStateManager.disableBlend();
 	}
 
 	private float getAlphaForRender(EntityGhost entity, float partialTicks) {

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderGhost.java
@@ -1,7 +1,5 @@
 package com.github.alexthe666.iceandfire.client.render.entity;
 
-import org.lwjgl.opengl.GL11;
-
 import com.github.alexthe666.iceandfire.client.model.ModelGhost;
 import com.github.alexthe666.iceandfire.entity.EntityGhost;
 
@@ -21,22 +19,21 @@ public class RenderGhost extends RenderLiving<EntityGhost> {
 
 	public RenderGhost(RenderManager renderManager) {
 		super(renderManager, MODEL, 0.55F);
-		preRenderProfileGhostClean();
+		this.shadowSize = 0.0F;
 	}
 
-	public void preRenderProfileGhostApply(EntityGhost entity, float partialTicks) {
-		float alphaForRender = getAlphaForRender(entity, partialTicks);
-		GlStateManager.color(1.0F, 1.0F, 1.0F, alphaForRender);
-		GlStateManager.depthMask(false);
+	@Override
+	protected void renderModel(EntityGhost entitylivingbaseIn, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch,
+			float scaleFactor) {
+		GlStateManager.disableAlpha();
 		GlStateManager.enableBlend();
 		GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.001F);
-	}
 
-	public void preRenderProfileGhostClean() {
+		GlStateManager.color(1.0F, 1.0F, 1.0F, this.getAlphaForRender(entitylivingbaseIn, scaleFactor));
+		super.renderModel(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor);
+
+		GlStateManager.enableAlpha();
 		GlStateManager.disableBlend();
-		GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
-		GlStateManager.depthMask(true);
 	}
 
 	private float getAlphaForRender(EntityGhost entity, float partialTicks) {
@@ -44,12 +41,6 @@ public class RenderGhost extends RenderLiving<EntityGhost> {
 			return MathHelper.clamp((101 - Math.min(entity.getDaytimeCounter(), 100)) / 100.0F, 0.0F, 1.0F);
 		}
 		return MathHelper.clamp((MathHelper.sin((entity.ticksExisted + partialTicks) * 0.1F) + 1.0F) * 0.5F + 0.1F, 0.0F, 1.0F);
-	}
-
-	@Override
-	public void preRenderCallback(EntityGhost entitylivingbaseIn, float partialTickTime) {
-		this.shadowSize = 0.0F;
-		preRenderProfileGhostApply(entitylivingbaseIn, partialTickTime);
 	}
 
 	@Override

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderPixie.java
@@ -21,6 +21,7 @@ import org.lwjgl.opengl.GL11;
 @SideOnly(Side.CLIENT)
 public class RenderPixie extends RenderLiving<EntityPixie> {
 
+	public static final ModelPixie PIXIE_MODEL = new ModelPixie();
 	public static final ResourceLocation TEXTURE_0 = new ResourceLocation("iceandfire:textures/models/pixie/pixie_0.png");
 	public static final ResourceLocation TEXTURE_1 = new ResourceLocation("iceandfire:textures/models/pixie/pixie_1.png");
 	public static final ResourceLocation TEXTURE_2 = new ResourceLocation("iceandfire:textures/models/pixie/pixie_2.png");
@@ -29,7 +30,7 @@ public class RenderPixie extends RenderLiving<EntityPixie> {
 	public static final ResourceLocation TEXTURE_5 = new ResourceLocation("iceandfire:textures/models/pixie/pixie_5.png");
 
 	public RenderPixie(RenderManager renderManager) {
-		super(renderManager, new ModelPixie(), 0.2F);
+		super(renderManager, PIXIE_MODEL, 0.2F);
 		this.layerRenderers.add(new LayerPixieItem(this));
 		this.layerRenderers.add(new LayerPixieGlow(this));
 	}

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/IceAndFireTEISR.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/IceAndFireTEISR.java
@@ -2,32 +2,30 @@ package com.github.alexthe666.iceandfire.client.render.tile;
 
 import com.github.alexthe666.iceandfire.client.model.ModelTrollWeapon;
 import com.github.alexthe666.iceandfire.item.ItemTrollWeapon;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class IceAndFireTEISR extends TileEntityItemStackRenderer {
 
-    private static final ModelBase MODEL = new ModelTrollWeapon();
+	private static final ModelBase MODEL = new ModelTrollWeapon();
 
-    @Override
-    public void renderByItem(ItemStack itemStackIn) {
-        if(itemStackIn.getItem() instanceof ItemTrollWeapon){
-            ItemTrollWeapon weaponItem = (ItemTrollWeapon)itemStackIn.getItem();
-            GL11.glPushMatrix();
-            GL11.glTranslatef(0.5F, -0.75F, 0.5F);
-            GL11.glPushMatrix();
-            Minecraft.getMinecraft().getTextureManager().bindTexture(weaponItem.weapon.TEXTURE);
-            GL11.glPushMatrix();
-            MODEL.render(null, 0, 0, 0, 0, 0, 0.0625F);
-            GL11.glPopMatrix();
-            GL11.glPopMatrix();
-            GL11.glPopMatrix();
-        }
-    }
+	@Override
+	public void renderByItem(ItemStack itemStackIn) {
+		if (itemStackIn.getItem() instanceof ItemTrollWeapon) {
+			ItemTrollWeapon weaponItem = (ItemTrollWeapon) itemStackIn.getItem();
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(0.5F, -0.75F, 0.5F);
+			Minecraft.getMinecraft().getTextureManager().bindTexture(weaponItem.weapon.TEXTURE);
+			MODEL.render(null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0625F);
+			GlStateManager.popMatrix();
+		}
+	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderEggInIce.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderEggInIce.java
@@ -1,13 +1,14 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
 import com.github.alexthe666.iceandfire.client.model.ModelDragonEgg;
-import com.github.alexthe666.iceandfire.enums.EnumDragonType;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityEggInIce;
 import com.github.alexthe666.iceandfire.enums.EnumDragonEgg;
+import com.github.alexthe666.iceandfire.enums.EnumDragonType;
+
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class RenderEggInIce extends TileEntitySpecialRenderer<TileEntityEggInIce> {
@@ -15,18 +16,15 @@ public class RenderEggInIce extends TileEntitySpecialRenderer<TileEntityEggInIce
 	private static final ModelDragonEgg MODEL = new ModelDragonEgg();
 
 	@Override
-	public void render(TileEntityEggInIce egg, double x, double y, double z, float f, int f1, float alpha) {
-		if (egg.type != null) {
-			GL11.glPushMatrix();
-			GL11.glTranslatef((float) x + 0.5F, (float) y - 0.75F, (float) z + 0.5F);
-			GL11.glPushMatrix();
-			EnumDragonEgg eggType = egg.type.dragonType != EnumDragonType.ICE ? EnumDragonEgg.BLUE : egg.type;
+	public void render(TileEntityEggInIce te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+		if (te.type != null) {
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x + 0.5D, y - 0.75D, z + 0.5D);
+			EnumDragonEgg eggType = te.type.dragonType != EnumDragonType.ICE ? EnumDragonEgg.BLUE : te.type;
 			this.bindTexture(RenderPodium.getEggTexture(eggType));
-			GL11.glPushMatrix();
 			MODEL.renderFrozen();
-			GL11.glPopMatrix();
-			GL11.glPopMatrix();
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderGorgonHead.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderGorgonHead.java
@@ -2,21 +2,22 @@ package com.github.alexthe666.iceandfire.client.render.tile;
 
 import com.github.alexthe666.iceandfire.client.model.ModelGorgonHead;
 import com.github.alexthe666.iceandfire.client.model.ModelGorgonHeadActive;
+
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class RenderGorgonHead extends TileEntitySpecialRenderer<TileEntity> {
 
-	private static final ResourceLocation ACTIVE_TEXTURE = new ResourceLocation("iceandfire:textures/models/gorgon/head_active.png");
-	private static final ResourceLocation INACTIVE_TEXTURE = new ResourceLocation("iceandfire:textures/models/gorgon/head_inactive.png");
 	private static final ModelBase ACTIVE_MODEL = new ModelGorgonHeadActive();
 	private static final ModelBase INACTIVE_MODEL = new ModelGorgonHead();
+	private static final ResourceLocation ACTIVE_TEXTURE = new ResourceLocation("iceandfire:textures/models/gorgon/head_active.png");
+	private static final ResourceLocation INACTIVE_TEXTURE = new ResourceLocation("iceandfire:textures/models/gorgon/head_inactive.png");
 	private final boolean active;
 
 	public RenderGorgonHead(boolean active) {
@@ -24,16 +25,17 @@ public class RenderGorgonHead extends TileEntitySpecialRenderer<TileEntity> {
 	}
 
 	@Override
-	public void render(TileEntity entity, double x, double y, double z, float f, int f1, float alpha) {
-		ModelBase model = active ? ACTIVE_MODEL : INACTIVE_MODEL;
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float) x + 0.5F, (float) y - 0.75F, (float) z + 0.5F);
-		GL11.glPushMatrix();
-		this.bindTexture(active ? ACTIVE_TEXTURE : INACTIVE_TEXTURE);
-		GL11.glPushMatrix();
-		model.render(null, 0, 0, 0, 0, 0, 0.0625F);
-		GL11.glPopMatrix();
-		GL11.glPopMatrix();
-		GL11.glPopMatrix();
+	public void render(TileEntity te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(x + 0.5D, y - 0.75D, z + 0.5D);
+		if (this.active) {
+			this.bindTexture(ACTIVE_TEXTURE);
+			ACTIVE_MODEL.render(null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0625F);
+		} else {
+			this.bindTexture(INACTIVE_TEXTURE);
+			INACTIVE_MODEL.render(null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0625F);
+		}
+		GlStateManager.popMatrix();
 	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
@@ -1,6 +1,5 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
-import com.github.alexthe666.iceandfire.client.model.ModelPixie;
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityJar;
 import net.ilexiconn.llibrary.client.util.ItemTESRContext;
@@ -13,8 +12,6 @@ import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
-
-	private static final ModelPixie MODEL_PIXIE = new ModelPixie();
 
 	@Override
 	public void render(TileEntityJar entity, double x, double y, double z, float f, int f1, float alpha) {
@@ -54,7 +51,7 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 				OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
 				GlStateManager.enableLighting();
 				GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-				MODEL_PIXIE.animateInJar(entity.hasProduced, entity, 0);
+				RenderPixie.PIXIE_MODEL.animateInJar(entity.hasProduced, entity, 0);
 				GL11.glEnable(GL11.GL_CULL_FACE);
 			}
 			GL11.glPopMatrix();

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
@@ -6,6 +6,7 @@ import com.github.alexthe666.iceandfire.entity.tile.TileEntityJar;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -18,13 +19,11 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 			GlStateManager.pushMatrix();
 			GlStateManager.translate(x + 0.5D, y + 1.501D, z + 0.5D);
 			GlStateManager.rotate(180.0F, 1.0F, 0.0F, 0.0F);
-			GlStateManager.pushMatrix();
 			GlStateManager.translate(0.0F, te.hasProduced ? 0.9F : 0.6F, 0.0F);
 			GlStateManager.rotate(interpolateRotation(te.prevRotationYaw, te.rotationYaw, partialTicks), 0.0F, 1.0F, 0.0F);
 			GlStateManager.scale(0.5F, 0.5F, 0.5F);
 
 			GlStateManager.disableCull();
-			GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
 
 			switch (te.pixieType) {
 				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
@@ -35,22 +34,19 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 				case 5: this.bindTexture(RenderPixie.TEXTURE_5); break;
 			}
 
-			GlStateManager.disableLighting();
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
-			GlStateManager.enableLighting();
-			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			RenderPixie.PIXIE_MODEL.animateInJar(te.hasProduced, te, 0.0F);
 
 			GlStateManager.enableCull();
 
-			GlStateManager.popMatrix();
 			GlStateManager.popMatrix();
 		}
 	}
 
 	private static float interpolateRotation(float prevYawOffset, float yawOffset, float partialTicks) {
 		float f = yawOffset - prevYawOffset;
-		f = (((f % 360.0F) + 540.0F) % 360.0F) - 180.0F;
+		int i = MathHelper.floor(f);
+		f = ((((i % 360) + 540) % 360) - 180) + (f - i);
 		return prevYawOffset + partialTicks * f;
 	}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
@@ -1,7 +1,5 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
-import org.lwjgl.opengl.GL11;
-
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityJar;
 
@@ -17,15 +15,15 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 	@Override
 	public void render(TileEntityJar te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
 		if (te.hasPixie) {
-			GL11.glPushMatrix();
-			GL11.glTranslated(x + 0.5D, y + 1.501D, z + 0.5D);
-			GL11.glRotatef(180.0F, 1.0F, 0.0F, 0.0F);
-			GL11.glPushMatrix();
-			GL11.glTranslatef(0.0F, te.hasProduced ? 0.9F : 0.6F, 0.0F);
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x + 0.5D, y + 1.501D, z + 0.5D);
+			GlStateManager.rotate(180.0F, 1.0F, 0.0F, 0.0F);
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(0.0F, te.hasProduced ? 0.9F : 0.6F, 0.0F);
 			GlStateManager.rotate(interpolateRotation(te.prevRotationYaw, te.rotationYaw, partialTicks), 0.0F, 1.0F, 0.0F);
-			GL11.glScalef(0.5F, 0.5F, 0.5F);
+			GlStateManager.scale(0.5F, 0.5F, 0.5F);
 
-			GL11.glDisable(GL11.GL_CULL_FACE);
+			GlStateManager.disableCull();
 			GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
 
 			switch (te.pixieType) {
@@ -43,10 +41,10 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			RenderPixie.PIXIE_MODEL.animateInJar(te.hasProduced, te, 0.0F);
 
-			GL11.glEnable(GL11.GL_CULL_FACE);
+			GlStateManager.enableCull();
 
-			GL11.glPopMatrix();
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
+			GlStateManager.popMatrix();
 		}
 	}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderJar.java
@@ -1,35 +1,34 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
+import org.lwjgl.opengl.GL11;
+
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityJar;
-import net.ilexiconn.llibrary.client.util.ItemTESRContext;
+
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 
 	@Override
-	public void render(TileEntityJar entity, double x, double y, double z, float f, int f1, float alpha) {
-		int meta = 0;
-		boolean hasPixie = false;
-		if (entity != null && entity.getWorld() != null) {
-			meta = entity.pixieType;
-			hasPixie = entity.hasPixie;
-		} else if (ItemTESRContext.INSTANCE.getCurrentStack() != null) {
-			hasPixie = ItemTESRContext.INSTANCE.getCurrentStack().getItemDamage() != 0;
-			meta = ItemTESRContext.INSTANCE.getCurrentStack().getItemDamage() - 1;
-		}
-		if (hasPixie) {
+	public void render(TileEntityJar te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+		if (te.hasPixie) {
 			GL11.glPushMatrix();
-			GL11.glTranslatef((float) x + 0.5F, (float) y + 1.501F, (float) z + 0.5F);
-			GL11.glRotatef(180, 1, 0, 0);
+			GL11.glTranslated(x + 0.5D, y + 1.501D, z + 0.5D);
+			GL11.glRotatef(180.0F, 1.0F, 0.0F, 0.0F);
 			GL11.glPushMatrix();
-			switch (meta) {
+			GL11.glTranslatef(0.0F, te.hasProduced ? 0.9F : 0.6F, 0.0F);
+			GlStateManager.rotate(interpolateRotation(te.prevRotationYaw, te.rotationYaw, partialTicks), 0.0F, 1.0F, 0.0F);
+			GL11.glScalef(0.5F, 0.5F, 0.5F);
+
+			GL11.glDisable(GL11.GL_CULL_FACE);
+			GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
+
+			switch (te.pixieType) {
 				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
 				case 1: this.bindTexture(RenderPixie.TEXTURE_1); break;
 				case 2: this.bindTexture(RenderPixie.TEXTURE_2); break;
@@ -37,31 +36,24 @@ public class RenderJar extends TileEntitySpecialRenderer<TileEntityJar> {
 				case 4: this.bindTexture(RenderPixie.TEXTURE_4); break;
 				case 5: this.bindTexture(RenderPixie.TEXTURE_5); break;
 			}
-			if (entity != null && entity.getWorld() != null) {
-				if (entity.hasProduced) {
-					GL11.glTranslatef(0F, 0.90F, 0F);
-				} else {
-					GL11.glTranslatef(0F, 0.60F, 0F);
-				}
-				GL11.glDisable(GL11.GL_CULL_FACE);
-				GlStateManager.rotate(this.interpolateRotation(entity.prevRotationYaw, entity.rotationYaw, f), 0.0F, 1.0F, 0.0F);
-				GL11.glScalef(0.50F, 0.50F, 0.50F);
-				GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
-				GlStateManager.disableLighting();
-				OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
-				GlStateManager.enableLighting();
-				GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-				RenderPixie.PIXIE_MODEL.animateInJar(entity.hasProduced, entity, 0);
-				GL11.glEnable(GL11.GL_CULL_FACE);
-			}
+
+			GlStateManager.disableLighting();
+			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
+			GlStateManager.enableLighting();
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+			RenderPixie.PIXIE_MODEL.animateInJar(te.hasProduced, te, 0.0F);
+
+			GL11.glEnable(GL11.GL_CULL_FACE);
+
 			GL11.glPopMatrix();
 			GL11.glPopMatrix();
 		}
 	}
 
-	protected float interpolateRotation(float prevYawOffset, float yawOffset, float partialTicks) {
+	private static float interpolateRotation(float prevYawOffset, float yawOffset, float partialTicks) {
 		float f = yawOffset - prevYawOffset;
 		f = (((f % 360.0F) + 540.0F) % 360.0F) - 180.0F;
 		return prevYawOffset + partialTicks * f;
 	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderLectern.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderLectern.java
@@ -33,7 +33,6 @@ public class RenderLectern extends TileEntitySpecialRenderer<TileEntityLectern> 
 		f4 = Math.max(0.0F, Math.min(1.0F, f4));
 		f5 = Math.max(0.0F, Math.min(1.0F, f5));
 
-		GlStateManager.enableCull();
 		book.render(null, 0, f4, f5, 1, 0.0F, 0.0625F);
 		GlStateManager.popMatrix();
 	}

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
@@ -1,21 +1,21 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
+import org.lwjgl.opengl.GL11;
+
 import com.github.alexthe666.iceandfire.block.BlockPixieHouse;
 import com.github.alexthe666.iceandfire.client.model.ModelPixieHouse;
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityPixieHouse;
+
 import net.ilexiconn.llibrary.client.util.ItemTESRContext;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieHouse> {
@@ -29,36 +29,36 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 	private static final ResourceLocation TEXTURE_5 = new ResourceLocation("iceandfire:textures/models/pixie/house/pixie_house_5.png");
 
 	@Override
-	public void render(TileEntityPixieHouse entity, double x, double y, double z, float f, int f1, float alpha) {
-		int rotation = 0;
+	public void render(TileEntityPixieHouse te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+		float rotation = 0.0F;
 		int meta = 0;
-		if (entity != null && entity.getWorld() != null && entity.getWorld().getBlockState(entity.getPos()).getBlock() instanceof BlockPixieHouse) {
-			IBlockState state = entity.getWorld().getBlockState(entity.getPos());
-			meta = entity.houseType;
-			if (state.getValue(BlockPixieHouse.FACING) == EnumFacing.NORTH) {
-				rotation = 180;
+		IBlockState state;
+		if (te != null && te.hasWorld() && (state = te.getWorld().getBlockState(te.getPos())).getBlock() instanceof BlockPixieHouse) {
+			switch (state.getValue(BlockPixieHouse.FACING)) {
+				case NORTH: rotation = 180.0F; break;
+				case WEST: rotation = -90.0F; break;
+				case EAST: rotation = 90.0F; break;
+				default: break;
 			}
-			else if (state.getValue(BlockPixieHouse.FACING) == EnumFacing.EAST) {
-				rotation = -90;
-			}
-			else if (state.getValue(BlockPixieHouse.FACING) == EnumFacing.WEST) {
-				rotation = 90;
-			}
-		} else if (ItemTESRContext.INSTANCE.getCurrentStack() != ItemStack.EMPTY) {
+			meta = te.houseType;
+		} else if (!ItemTESRContext.INSTANCE.getCurrentStack().isEmpty()) {
 			meta = ItemTESRContext.INSTANCE.getCurrentStack().getItemDamage();
 		}
+
 		GL11.glPushMatrix();
-		GL11.glTranslatef((float) x + 0.5F, (float) y + 1.501F, (float) z + 0.5F);
+		GL11.glTranslated(x + 0.5D, y + 1.501D, z + 0.5D);
 		GL11.glPushMatrix();
-		GL11.glRotatef(180, 1, 0, 0);
-		GL11.glRotatef(rotation, 0, 1F, 0);
-		if (entity != null && entity.getWorld() != null && entity.hasPixie) {
+		GL11.glRotatef(180.0F, 1.0F, 0.0F, 0.0F);
+		GL11.glRotatef(rotation, 0.0F, 1.0F, 0.0F);
+
+		if (te != null && te.hasWorld() && te.hasPixie) {
 			GL11.glPushMatrix();
-			GL11.glTranslatef(0F, 0.95F, 0F);
+			GL11.glTranslatef(0.0F, 0.95F, 0.0F);
 			GL11.glScalef(0.55F, 0.55F, 0.55F);
 			GL11.glPushMatrix();
-			//GL11.glRotatef(MathHelper.clampAngle(entity.ticksExisted * 3), 0, 1, 0);
-			switch (entity.pixieType) {
+			GL11.glPushMatrix();
+
+			switch (te.pixieType) {
 				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
 				case 1: this.bindTexture(RenderPixie.TEXTURE_1); break;
 				case 2: this.bindTexture(RenderPixie.TEXTURE_2); break;
@@ -66,44 +66,54 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 				case 4: this.bindTexture(RenderPixie.TEXTURE_4); break;
 				case 5: this.bindTexture(RenderPixie.TEXTURE_5); break;
 			}
-			GL11.glPushMatrix();
+
 			GlStateManager.enableBlend();
 			GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.CONSTANT_ALPHA);
 			GlStateManager.disableLighting();
 			GlStateManager.depthMask(true);
-			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 61680.0F, 0.0F);
 			GlStateManager.enableLighting();
-			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			GlStateManager.enableColorMaterial();
-			RenderPixie.PIXIE_MODEL.animateInHouse(entity);
-			GlStateManager.disableColorMaterial();
-			int i = entity.getWorld().getCombinedLight(entity.getPos(), entity.getWorld().getLightFor(EnumSkyBlock.BLOCK, entity.getPos()));
+
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 61680.0F, 0.0F);
+			RenderPixie.PIXIE_MODEL.animateInHouse(te);
+			int i = te.getWorld().getCombinedLight(te.getPos(), te.getWorld().getLightFor(EnumSkyBlock.BLOCK, te.getPos()));
 			int j = i % 65536;
 			int k = i / 65536;
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) j, (float) k);
+
+			GlStateManager.disableColorMaterial();
 			GlStateManager.depthMask(true);
 			GlStateManager.disableBlend();
 			GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
 			GlStateManager.enableTexture2D();
 			GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+
 			GL11.glPopMatrix();
 			GL11.glPopMatrix();
 			GL11.glPopMatrix();
 		}
+
+		GL11.glPushMatrix();
+
+		GL11.glDisable(GL11.GL_CULL_FACE);
+
 		switch (meta) {
-			case 0: this.bindTexture(TEXTURE_0); break;
+			default: this.bindTexture(TEXTURE_0); break;
 			case 1: this.bindTexture(TEXTURE_1); break;
 			case 2: this.bindTexture(TEXTURE_2); break;
 			case 3: this.bindTexture(TEXTURE_3); break;
 			case 4: this.bindTexture(TEXTURE_4); break;
 			case 5: this.bindTexture(TEXTURE_5); break;
 		}
-		GL11.glPushMatrix();
-		GL11.glDisable(GL11.GL_CULL_FACE);
+
 		MODEL.render(0.0625F);
+
 		GL11.glEnable(GL11.GL_CULL_FACE);
+
 		GL11.glPopMatrix();
 		GL11.glPopMatrix();
 		GL11.glPopMatrix();
 	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
@@ -1,7 +1,5 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
-import org.lwjgl.opengl.GL11;
-
 import com.github.alexthe666.iceandfire.block.BlockPixieHouse;
 import com.github.alexthe666.iceandfire.client.model.ModelPixieHouse;
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
@@ -45,18 +43,18 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 			meta = ItemTESRContext.INSTANCE.getCurrentStack().getItemDamage();
 		}
 
-		GL11.glPushMatrix();
-		GL11.glTranslated(x + 0.5D, y + 1.501D, z + 0.5D);
-		GL11.glPushMatrix();
-		GL11.glRotatef(180.0F, 1.0F, 0.0F, 0.0F);
-		GL11.glRotatef(rotation, 0.0F, 1.0F, 0.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(x + 0.5D, y + 1.501D, z + 0.5D);
+		GlStateManager.pushMatrix();
+		GlStateManager.rotate(180.0F, 1.0F, 0.0F, 0.0F);
+		GlStateManager.rotate(rotation, 0.0F, 1.0F, 0.0F);
 
 		if (te != null && te.hasWorld() && te.hasPixie) {
-			GL11.glPushMatrix();
-			GL11.glTranslatef(0.0F, 0.95F, 0.0F);
-			GL11.glScalef(0.55F, 0.55F, 0.55F);
-			GL11.glPushMatrix();
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(0.0F, 0.95F, 0.0F);
+			GlStateManager.scale(0.55F, 0.55F, 0.55F);
+			GlStateManager.pushMatrix();
+			GlStateManager.pushMatrix();
 
 			switch (te.pixieType) {
 				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
@@ -89,14 +87,14 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 			GlStateManager.enableTexture2D();
 			GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
 
-			GL11.glPopMatrix();
-			GL11.glPopMatrix();
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
+			GlStateManager.popMatrix();
+			GlStateManager.popMatrix();
 		}
 
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 
-		GL11.glDisable(GL11.GL_CULL_FACE);
+		GlStateManager.disableCull();
 
 		switch (meta) {
 			default: this.bindTexture(TEXTURE_0); break;
@@ -109,11 +107,11 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 
 		MODEL.render(0.0625F);
 
-		GL11.glEnable(GL11.GL_CULL_FACE);
+		GlStateManager.enableCull();
 
-		GL11.glPopMatrix();
-		GL11.glPopMatrix();
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
+		GlStateManager.popMatrix();
+		GlStateManager.popMatrix();
 	}
 
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.EnumSkyBlock;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -45,56 +44,8 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 
 		GlStateManager.pushMatrix();
 		GlStateManager.translate(x + 0.5D, y + 1.501D, z + 0.5D);
-		GlStateManager.pushMatrix();
 		GlStateManager.rotate(180.0F, 1.0F, 0.0F, 0.0F);
 		GlStateManager.rotate(rotation, 0.0F, 1.0F, 0.0F);
-
-		if (te != null && te.hasWorld() && te.hasPixie) {
-			GlStateManager.pushMatrix();
-			GlStateManager.translate(0.0F, 0.95F, 0.0F);
-			GlStateManager.scale(0.55F, 0.55F, 0.55F);
-			GlStateManager.pushMatrix();
-			GlStateManager.pushMatrix();
-
-			switch (te.pixieType) {
-				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
-				case 1: this.bindTexture(RenderPixie.TEXTURE_1); break;
-				case 2: this.bindTexture(RenderPixie.TEXTURE_2); break;
-				case 3: this.bindTexture(RenderPixie.TEXTURE_3); break;
-				case 4: this.bindTexture(RenderPixie.TEXTURE_4); break;
-				case 5: this.bindTexture(RenderPixie.TEXTURE_5); break;
-			}
-
-			GlStateManager.enableBlend();
-			GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.CONSTANT_ALPHA);
-			GlStateManager.disableLighting();
-			GlStateManager.depthMask(true);
-			GlStateManager.enableLighting();
-			GlStateManager.enableColorMaterial();
-			GlStateManager.disableCull();
-
-			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 61680.0F, 0.0F);
-			RenderPixie.PIXIE_MODEL.animateInHouse(te);
-			int i = te.getWorld().getCombinedLight(te.getPos(), te.getWorld().getLightFor(EnumSkyBlock.BLOCK, te.getPos()));
-			int j = i % 65536;
-			int k = i / 65536;
-			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) j, (float) k);
-
-			GlStateManager.enableCull();
-			GlStateManager.disableColorMaterial();
-			GlStateManager.depthMask(true);
-			GlStateManager.disableBlend();
-			GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
-			GlStateManager.enableTexture2D();
-			GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
-
-			GlStateManager.popMatrix();
-			GlStateManager.popMatrix();
-			GlStateManager.popMatrix();
-		}
-
-		GlStateManager.pushMatrix();
 
 		GlStateManager.disableCull();
 
@@ -109,10 +60,25 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 
 		MODEL.render(0.0625F);
 
+		if (te != null && te.hasWorld() && te.hasPixie) {
+			GlStateManager.translate(0.0F, 0.95F, 0.0F);
+			GlStateManager.scale(0.55F, 0.55F, 0.55F);
+
+			switch (te.pixieType) {
+				default: this.bindTexture(RenderPixie.TEXTURE_0); break;
+				case 1: this.bindTexture(RenderPixie.TEXTURE_1); break;
+				case 2: this.bindTexture(RenderPixie.TEXTURE_2); break;
+				case 3: this.bindTexture(RenderPixie.TEXTURE_3); break;
+				case 4: this.bindTexture(RenderPixie.TEXTURE_4); break;
+				case 5: this.bindTexture(RenderPixie.TEXTURE_5); break;
+			}
+
+			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 256.0F, 0.0F);
+			RenderPixie.PIXIE_MODEL.animateInHouse(te);
+		}
+
 		GlStateManager.enableCull();
 
-		GlStateManager.popMatrix();
-		GlStateManager.popMatrix();
 		GlStateManager.popMatrix();
 	}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
@@ -71,6 +71,7 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 			GlStateManager.depthMask(true);
 			GlStateManager.enableLighting();
 			GlStateManager.enableColorMaterial();
+			GlStateManager.disableCull();
 
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 61680.0F, 0.0F);
@@ -80,6 +81,7 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 			int k = i / 65536;
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) j, (float) k);
 
+			GlStateManager.enableCull();
 			GlStateManager.disableColorMaterial();
 			GlStateManager.depthMask(true);
 			GlStateManager.disableBlend();

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPixieHouse.java
@@ -1,7 +1,6 @@
 package com.github.alexthe666.iceandfire.client.render.tile;
 
 import com.github.alexthe666.iceandfire.block.BlockPixieHouse;
-import com.github.alexthe666.iceandfire.client.model.ModelPixie;
 import com.github.alexthe666.iceandfire.client.model.ModelPixieHouse;
 import com.github.alexthe666.iceandfire.client.render.entity.RenderPixie;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityPixieHouse;
@@ -22,7 +21,6 @@ import org.lwjgl.opengl.GL11;
 public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieHouse> {
 
 	private static final ModelPixieHouse MODEL = new ModelPixieHouse();
-	private static final ModelPixie MODEL_PIXIE = new ModelPixie();
 	private static final ResourceLocation TEXTURE_0 = new ResourceLocation("iceandfire:textures/models/pixie/house/pixie_house_0.png");
 	private static final ResourceLocation TEXTURE_1 = new ResourceLocation("iceandfire:textures/models/pixie/house/pixie_house_1.png");
 	private static final ResourceLocation TEXTURE_2 = new ResourceLocation("iceandfire:textures/models/pixie/house/pixie_house_2.png");
@@ -77,7 +75,7 @@ public class RenderPixieHouse extends TileEntitySpecialRenderer<TileEntityPixieH
 			GlStateManager.enableLighting();
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			GlStateManager.enableColorMaterial();
-			MODEL_PIXIE.animateInHouse(entity);
+			RenderPixie.PIXIE_MODEL.animateInHouse(entity);
 			GlStateManager.disableColorMaterial();
 			int i = entity.getWorld().getCombinedLight(entity.getPos(), entity.getWorld().getLightFor(EnumSkyBlock.BLOCK, entity.getPos()));
 			int j = i % 65536;

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPodium.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPodium.java
@@ -8,73 +8,68 @@ import com.github.alexthe666.iceandfire.entity.tile.TileEntityPodium;
 import com.github.alexthe666.iceandfire.enums.EnumDragonEgg;
 import com.github.alexthe666.iceandfire.item.ItemDragonEgg;
 import com.github.alexthe666.iceandfire.item.ItemMyrmexEgg;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.tileentity.TileEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
-import org.lwjgl.opengl.GL11;
 
 public class RenderPodium extends TileEntitySpecialRenderer<TileEntityPodium> {
 
-    private static final ModelDragonEgg MODEL = new ModelDragonEgg();
+	public static final ModelDragonEgg MODEL = new ModelDragonEgg();
 
-    protected static ResourceLocation getEggTexture(EnumDragonEgg type) {
-        switch (type) {
-            default: return RenderDragonEgg.EGG_RED;
-            case GREEN: return RenderDragonEgg.EGG_GREEN;
-            case BRONZE: return RenderDragonEgg.EGG_BRONZE;
-            case GRAY: return RenderDragonEgg.EGG_GREY;
-            case BLUE: return RenderDragonEgg.EGG_BLUE;
-            case WHITE: return RenderDragonEgg.EGG_WHITE;
-            case SAPPHIRE: return RenderDragonEgg.EGG_SAPPHIRE;
-            case SILVER: return RenderDragonEgg.EGG_SILVER;
-            case ELECTRIC: return RenderDragonEgg.EGG_ELECTRIC;
-            case AMETHYST: return RenderDragonEgg.EGG_AMETHYST;
-            case COPPER: return RenderDragonEgg.EGG_COPPER;
-            case BLACK: return RenderDragonEgg.EGG_BLACK;
-        }
-    }
+	@Override
+	public void render(TileEntityPodium te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+		ItemStack stack = te.getStackInSlot(0);
+		Item item;
+		if (!stack.isEmpty() && ((item = stack.getItem()) instanceof ItemDragonEgg || item instanceof ItemMyrmexEgg)) {
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x + 0.5D, y + 0.475D, z + 0.5D);
 
-    @Override
-    public void render(TileEntityPodium podium, double x, double y, double z, float f, int f1, float alpha) {
-        if (!podium.getStackInSlot(0).isEmpty()) {
-            if (podium.getStackInSlot(0).getItem() instanceof ItemDragonEgg) {
-                ItemDragonEgg item = (ItemDragonEgg) podium.getStackInSlot(0).getItem();
-                GL11.glPushMatrix();
-                GL11.glTranslatef((float) x + 0.5F, (float) y + 0.475F, (float) z + 0.5F);
-                GL11.glPushMatrix();
-                this.bindTexture(getEggTexture(item.type));
-                GL11.glPushMatrix();
-                MODEL.renderPodium();
-                GL11.glPopMatrix();
-                GL11.glPopMatrix();
-                GL11.glPopMatrix();
-            } else if (podium.getStackInSlot(0).getItem() instanceof ItemMyrmexEgg) {
-                boolean jungle = podium.getStackInSlot(0).getItem() == ModItems.myrmex_jungle_egg;
-                GL11.glPushMatrix();
-                GL11.glTranslatef((float) x + 0.5F, (float) y + 0.475F, (float) z + 0.5F);
-                GL11.glPushMatrix();
-                this.bindTexture(jungle ? RenderMyrmexEgg.EGG_JUNGLE : RenderMyrmexEgg.EGG_DESERT);
-                GL11.glPushMatrix();
-                MODEL.renderPodium();
-                GL11.glPopMatrix();
-                GL11.glPopMatrix();
-                GL11.glPopMatrix();
-            } else {
-                GL11.glPushMatrix();
-                float f2 = ((float) podium.prevTicksExisted + (podium.ticksExisted - podium.prevTicksExisted) * f);
-                float f3 = MathHelper.sin(f2 / 10.0F) * 0.1F + 0.1F;
-                GL11.glTranslatef((float) x + 0.5F, (float) y + 1.55F + f3, (float) z + 0.5F);
-                float f4 = (f2 / 20.0F) * (180F / (float) Math.PI);
-                GlStateManager.rotate(f4, 0.0F, 1.0F, 0.0F);
-                GL11.glPushMatrix();
-                Minecraft.getMinecraft().getItemRenderer().renderItem(Minecraft.getMinecraft().player, podium.getStackInSlot(0), ItemCameraTransforms.TransformType.GROUND);
-                GL11.glPopMatrix();
-                GL11.glPopMatrix();
-            }
-        }
-    }
+			if (item instanceof ItemDragonEgg) {
+				this.bindTexture(getEggTexture(((ItemDragonEgg) item).type));
+			} else if (item instanceof ItemMyrmexEgg) {
+				this.bindTexture(item == ModItems.myrmex_jungle_egg ? RenderMyrmexEgg.EGG_JUNGLE : RenderMyrmexEgg.EGG_DESERT);
+			}
+
+			MODEL.renderPodium();
+
+			GlStateManager.popMatrix();
+		} else {
+			GlStateManager.pushMatrix();
+
+			float ageInTicks = te.ticksExisted + partialTicks;
+			float yOffset = MathHelper.sin(ageInTicks / 10.0F) * 0.1F + 0.1F;
+			GlStateManager.translate(x + 0.5D, y + 1.55D + yOffset, z + 0.5D);
+			float rotation = (float) Math.toDegrees(ageInTicks / 20.0F);
+			GlStateManager.rotate(rotation, 0.0F, 1.0F, 0.0F);
+
+			Minecraft mc = Minecraft.getMinecraft();
+			mc.getItemRenderer().renderItem(mc.player, stack, TransformType.GROUND);
+
+			GlStateManager.popMatrix();
+		}
+	}
+
+	public static ResourceLocation getEggTexture(EnumDragonEgg type) {
+		switch (type) {
+			default: return RenderDragonEgg.EGG_RED;
+			case GREEN: return RenderDragonEgg.EGG_GREEN;
+			case BRONZE: return RenderDragonEgg.EGG_BRONZE;
+			case GRAY: return RenderDragonEgg.EGG_GREY;
+			case BLUE: return RenderDragonEgg.EGG_BLUE;
+			case WHITE: return RenderDragonEgg.EGG_WHITE;
+			case SAPPHIRE: return RenderDragonEgg.EGG_SAPPHIRE;
+			case SILVER: return RenderDragonEgg.EGG_SILVER;
+			case ELECTRIC: return RenderDragonEgg.EGG_ELECTRIC;
+			case AMETHYST: return RenderDragonEgg.EGG_AMETHYST;
+			case COPPER: return RenderDragonEgg.EGG_COPPER;
+			case BLACK: return RenderDragonEgg.EGG_BLACK;
+		}
+	}
+
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPodium.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/tile/RenderPodium.java
@@ -19,6 +19,8 @@ import org.lwjgl.opengl.GL11;
 
 public class RenderPodium extends TileEntitySpecialRenderer<TileEntityPodium> {
 
+    private static final ModelDragonEgg MODEL = new ModelDragonEgg();
+
     protected static ResourceLocation getEggTexture(EnumDragonEgg type) {
         switch (type) {
             default: return RenderDragonEgg.EGG_RED;
@@ -38,7 +40,6 @@ public class RenderPodium extends TileEntitySpecialRenderer<TileEntityPodium> {
 
     @Override
     public void render(TileEntityPodium podium, double x, double y, double z, float f, int f1, float alpha) {
-        ModelDragonEgg model = new ModelDragonEgg();
         if (!podium.getStackInSlot(0).isEmpty()) {
             if (podium.getStackInSlot(0).getItem() instanceof ItemDragonEgg) {
                 ItemDragonEgg item = (ItemDragonEgg) podium.getStackInSlot(0).getItem();
@@ -47,7 +48,7 @@ public class RenderPodium extends TileEntitySpecialRenderer<TileEntityPodium> {
                 GL11.glPushMatrix();
                 this.bindTexture(getEggTexture(item.type));
                 GL11.glPushMatrix();
-                model.renderPodium();
+                MODEL.renderPodium();
                 GL11.glPopMatrix();
                 GL11.glPopMatrix();
                 GL11.glPopMatrix();
@@ -58,7 +59,7 @@ public class RenderPodium extends TileEntitySpecialRenderer<TileEntityPodium> {
                 GL11.glPushMatrix();
                 this.bindTexture(jungle ? RenderMyrmexEgg.EGG_JUNGLE : RenderMyrmexEgg.EGG_DESERT);
                 GL11.glPushMatrix();
-                model.renderPodium();
+                MODEL.renderPodium();
                 GL11.glPopMatrix();
                 GL11.glPopMatrix();
                 GL11.glPopMatrix();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGhost.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGhost.java
@@ -408,4 +408,10 @@ public class EntityGhost extends EntityMob implements IAnimatedEntity, IVillager
             }
         }
     }
+
+	@Override
+	public boolean shouldRenderInPass(int pass) {
+		return pass == 1;
+	}
+
 }


### PR DESCRIPTION
This PR fixes issues, improves performance, and cleans up several renderers.

Fixes:
- Fix Dread Lich skull renderer creating a new model instance every frame (memory leak)
- Fix Podium renderer creating a new model instance every frame (memory leak)
- Fix Ghost renderer corrupting OpenGL state
- Fix Royal Myrmex model corrupting OpenGL state
- Fix Dread Lich skull renderer corrupting OpenGL state
- Fix Ghosts sometimes rendering behind solid entities
- Fix Pixies in houses rendering with face culling enabled
- Fix Dread Lich skull rotation when rotation changes rapidly

Performance:
- Remove a lot of unnecessary OpenGL calls
- Fix duplicate Pixie model instances
- Other minor improvements (e.g. caching block states in local variables)
