### PR TITLE
Blindfold and Earplug Baublefied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
+    implementation fg.deobf("curse.maven:baubles-${baubles_version}")
     implementation fg.deobf("curse.maven:llibrary-${llibrary_version}")
     implementation fg.deobf("curse.maven:thaumcraft-${thaumcraft_version}")
     implementation fg.deobf("curse.maven:hwyla-${hwyla_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ forge_version=14.23.5.2860
 mappings_channel=stable
 mappings_version=39-1.12
 
+baubles_version=227083:2518667
 hwyla_version=253449:2568751
 jei_version=238222:2561546
 llibrary_version=243298:2504999

--- a/src/main/java/com/github/alexthe666/iceandfire/api/SensesUtils.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/api/SensesUtils.java
@@ -1,0 +1,39 @@
+package com.github.alexthe666.iceandfire.api;
+
+import baubles.api.BaubleType;
+import baubles.api.BaublesApi;
+import com.github.alexthe666.iceandfire.integration.CompatLoadUtil;
+import com.github.alexthe666.iceandfire.item.IafItemRegistry;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+
+public class SensesUtils {
+
+    public static boolean isBlind(EntityLivingBase entity){
+        if(entity == null) return false;
+        if(entity.isPotionActive(MobEffects.BLINDNESS)) return true;
+
+        ItemStack helmet = entity.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
+        if(helmet.getItem() == IafItemRegistry.blindfold)
+            return true;
+        else if(CompatLoadUtil.isBaublesLoaded() && entity instanceof EntityPlayer)
+            return BaublesApi.getBaublesHandler((EntityPlayer)entity).getStackInSlot(BaubleType.HEAD.getValidSlots()[0]).getItem() == IafItemRegistry.blindfold;
+
+        return false;
+    }
+
+    public static boolean isDeaf(EntityLivingBase entity){
+        if(entity == null) return false;
+
+        ItemStack helmet = entity.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
+        if(helmet.getItem() == IafItemRegistry.earplugs || helmet != ItemStack.EMPTY && helmet.getItem().getTranslationKey().contains("earmuff"))
+            return true;
+        else if (CompatLoadUtil.isBaublesLoaded() && entity instanceof EntityPlayer)
+            return BaublesApi.getBaublesHandler((EntityPlayer)entity).getStackInSlot(BaubleType.HEAD.getValidSlots()[0]).getItem() == IafItemRegistry.earplugs;
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/capability/entityeffect/EntityEffectCapability.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/capability/entityeffect/EntityEffectCapability.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.capability.entityeffect;
 
 import com.github.alexthe666.iceandfire.IceAndFireConfig;
 import com.github.alexthe666.iceandfire.api.IEntityEffectCapability;
+import com.github.alexthe666.iceandfire.api.SensesUtils;
 import com.github.alexthe666.iceandfire.entity.*;
 import com.github.alexthe666.iceandfire.entity.util.IHearsSiren;
 import net.minecraft.entity.Entity;
@@ -18,7 +19,7 @@ public class EntityEffectCapability implements IEntityEffectCapability {
         CHARMED(0, true, false) {
             @Override
             public boolean canBeApplied(EntityLivingBase entity) {
-                return super.canBeApplied(entity) && (EntitySiren.isDrawnToSong(entity)) && !EntitySiren.isWearingEarplugs(entity);
+                return super.canBeApplied(entity) && (EntitySiren.isDrawnToSong(entity)) && !SensesUtils.isDeaf(entity);
             }
         },
         FROZEN(1, true, true) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.entity;
 
 import com.github.alexthe666.iceandfire.IceAndFireConfig;
 import com.github.alexthe666.iceandfire.api.FoodUtils;
+import com.github.alexthe666.iceandfire.api.SensesUtils;
 import com.github.alexthe666.iceandfire.misc.IafSoundRegistry;
 import com.github.alexthe666.iceandfire.entity.ai.*;
 import com.github.alexthe666.iceandfire.entity.util.IVillagerFear;
@@ -234,9 +235,7 @@ public class EntityCockatrice extends EntityTameable implements IAnimatedEntity,
 
     @Nullable
     public EntityLivingBase getTargetedEntity() {
-        boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-                this.getAttackTarget() != null && this.getAttackTarget().isPotionActive(MobEffects.BLINDNESS) ||
-                this.getAttackTarget() != null && EntityGorgon.isBlindfolded(this.getAttackTarget());
+        boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(this.getAttackTarget());
         if(blindness){
             return null;
         }
@@ -471,9 +470,7 @@ public class EntityCockatrice extends EntityTameable implements IAnimatedEntity,
                 forcePreyToLook((EntityLiving) this.getAttackTarget());
             }
         }
-        boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-                this.getAttackTarget() != null && this.getAttackTarget().isPotionActive(MobEffects.BLINDNESS) ||
-                this.getAttackTarget() != null && EntityGorgon.isBlindfolded(this.getAttackTarget());
+        boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(this.getAttackTarget());
         if(blindness){
             this.setStaring(false);
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -5,6 +5,7 @@ import com.github.alexthe666.iceandfire.IceAndFireConfig;
 import com.github.alexthe666.iceandfire.api.FoodUtils;
 import com.github.alexthe666.iceandfire.api.IEntityEffectCapability;
 import com.github.alexthe666.iceandfire.api.InFCapabilities;
+import com.github.alexthe666.iceandfire.api.SensesUtils;
 import com.github.alexthe666.iceandfire.client.model.IFChainBuffer;
 import com.github.alexthe666.iceandfire.client.model.util.LegSolverQuadruped;
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
@@ -2362,7 +2363,7 @@ public abstract class EntityDragonBase extends EntityTameable implements IMultip
                     if (this.isOwner(living) || this.isOwnersPet(living)) {
                         living.addPotionEffect(new PotionEffect(MobEffects.STRENGTH, 30 * size));
                     } else {
-                        if (living.getItemStackFromSlot(EntityEquipmentSlot.HEAD).getItem() != IafItemRegistry.earplugs) {
+                        if (!SensesUtils.isDeaf(living)) {
                             living.addPotionEffect(new PotionEffect(MobEffects.WEAKNESS, 30 * size));
                         }
                     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
@@ -4,6 +4,7 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.IceAndFireConfig;
 import com.github.alexthe666.iceandfire.api.IEntityEffectCapability;
 import com.github.alexthe666.iceandfire.api.InFCapabilities;
+import com.github.alexthe666.iceandfire.api.SensesUtils;
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 import com.github.alexthe666.iceandfire.misc.IafSoundRegistry;
 import com.github.alexthe666.iceandfire.entity.ai.GorgonAIStareAttack;
@@ -58,10 +59,6 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 		vec3d1 = vec3d1.normalize();
 		double d1 = vec3d.dotProduct(vec3d1);
 		return d1 > 1.0D - degree / d0 && looker.canEntityBeSeen(seen) && !isStoneMob(seen);
-	}
-
-	public static boolean isBlindfolded(EntityLivingBase attackTarget) {
-		return attackTarget != null && attackTarget.getItemStackFromSlot(EntityEquipmentSlot.HEAD).getItem() == IafItemRegistry.blindfold;
 	}
 
 	@Nullable
@@ -128,10 +125,8 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 	}
 
 	public boolean attackEntityAsMob(Entity entityIn) {
-		boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-				this.getAttackTarget() != null && this.getAttackTarget().isPotionActive(MobEffects.BLINDNESS) ||
-				this.getAttackTarget() != null && this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues) this.getAttackTarget()).canBeTurnedToStone() ||
-				this.getAttackTarget() != null && isBlindfolded(this.getAttackTarget());
+		boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(this.getAttackTarget()) ||
+				this.getAttackTarget() != null && this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues) this.getAttackTarget()).canBeTurnedToStone();
 		if (blindness && this.deathTime == 0) {
 			if (this.getAnimation() != ANIMATION_HIT) {
 				this.setAnimation(ANIMATION_HIT);
@@ -151,10 +146,8 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 	public void setAttackTarget(@Nullable EntityLivingBase entitylivingbaseIn) {
 		super.setAttackTarget(entitylivingbaseIn);
 		if (entitylivingbaseIn != null && !world.isRemote) {
-			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-					entitylivingbaseIn.isPotionActive(MobEffects.BLINDNESS) ||
-					entitylivingbaseIn instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues) entitylivingbaseIn).canBeTurnedToStone() ||
-					isBlindfolded(entitylivingbaseIn);
+			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(entitylivingbaseIn) ||
+					entitylivingbaseIn instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues) entitylivingbaseIn).canBeTurnedToStone();
 			if (blindness && this.deathTime == 0) {
 				this.tasks.removeTask(aiStare);
 				this.tasks.addTask(3, aiMelee);
@@ -207,10 +200,8 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 		super.onLivingUpdate();
 		if(statueCooldown > 0) statueCooldown--;
 		if (this.getAttackTarget() != null) {
-			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-					this.getAttackTarget().isPotionActive(MobEffects.BLINDNESS) ||
-					this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues)this.getAttackTarget()).canBeTurnedToStone() ||
-					isBlindfolded(this.getAttackTarget());
+			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(this.getAttackTarget()) ||
+					this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues)this.getAttackTarget()).canBeTurnedToStone();
 			this.getLookHelper().setLookPosition(this.getAttackTarget().posX, this.getAttackTarget().posY + (double) this.getAttackTarget().getEyeHeight(), this.getAttackTarget().posZ, (float) this.getHorizontalFaceSpeed(), (float) this.getVerticalFaceSpeed());
 			if (!blindness && this.deathTime == 0 && this.getAttackTarget() instanceof EntityLiving && !(this.getAttackTarget() instanceof EntityPlayer)) {
 				forcePreyToLook((EntityLiving) this.getAttackTarget());
@@ -218,10 +209,8 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 		}
 
 		if (this.getAttackTarget() != null && isEntityLookingAt(this, this.getAttackTarget(), 0.4) && isEntityLookingAt(this.getAttackTarget(), this, 0.4)) {
-			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) ||
-					this.getAttackTarget().isPotionActive(MobEffects.BLINDNESS) ||
-					this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues)this.getAttackTarget()).canBeTurnedToStone() ||
-					isBlindfolded(this.getAttackTarget());
+			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || SensesUtils.isBlind(this.getAttackTarget()) ||
+					this.getAttackTarget() instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues)this.getAttackTarget()).canBeTurnedToStone();
 			if (!blindness && this.deathTime == 0) {
 				if (this.getAnimation() != ANIMATION_SCARE) {
 					this.playSound(IafSoundRegistry.GORGON_ATTACK, 1, 1);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySiren.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySiren.java
@@ -4,6 +4,7 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.IceAndFireConfig;
 import com.github.alexthe666.iceandfire.api.IEntityEffectCapability;
 import com.github.alexthe666.iceandfire.api.InFCapabilities;
+import com.github.alexthe666.iceandfire.api.SensesUtils;
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 import com.github.alexthe666.iceandfire.misc.IafSoundRegistry;
 import com.github.alexthe666.iceandfire.entity.ai.*;
@@ -294,11 +295,6 @@ public class EntitySiren extends EntityMob implements IAnimatedEntity, IVillager
         this.setSinging(true);
     }
 
-    public static boolean isWearingEarplugs(EntityLivingBase entity) {
-        ItemStack helmet = entity.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
-        return helmet.getItem() == IafItemRegistry.earplugs || helmet != ItemStack.EMPTY && helmet.getItem().getTranslationKey().contains("earmuff");
-    }
-
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount) {
         if (source.getTrueSource() != null && source.getTrueSource() instanceof EntityLivingBase) {
@@ -324,7 +320,7 @@ public class EntitySiren extends EntityMob implements IAnimatedEntity, IVillager
             List<EntityLivingBase> entities = world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(50, 12, 50), SIREN_PREY);
             for (EntityLivingBase entity : entities) {
                 IEntityEffectCapability capability = InFCapabilities.getEntityEffectCapability(entity);
-                if(!isWearingEarplugs(entity) && capability != null && (!capability.isCharmed() || capability.getSiren(world) == null)) {
+                if(!SensesUtils.isDeaf(entity) && capability != null && (!capability.isCharmed() || capability.getSiren(world) == null)) {
                     capability.setCharmed(this.getEntityId());
                 }
             }

--- a/src/main/java/com/github/alexthe666/iceandfire/integration/CompatLoadUtil.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/integration/CompatLoadUtil.java
@@ -4,6 +4,8 @@ import net.minecraftforge.fml.common.Loader;
 
 public abstract class CompatLoadUtil {
 
+    private static final String BAUBLES_MODID = "baubles";
+    private static Boolean baublesLoaded;
     private static final String CLAIMIT_MODID = "claimit";
     private static Boolean claimitLoaded;
     private static final String VARIED_COMMODITIES_MODID = "variedcommodities";
@@ -17,6 +19,11 @@ public abstract class CompatLoadUtil {
 
     private static final String THE_ONE_PROBE_MODID = "theoneprobe";
     private static Boolean theOneProbeLoaded;
+
+    public static boolean isBaublesLoaded(){
+        if(baublesLoaded == null) baublesLoaded = Loader.isModLoaded(BAUBLES_MODID);
+        return baublesLoaded;
+    }
 
     public static boolean isClaimItLoaded() {
         if(claimitLoaded == null) claimitLoaded = Loader.isModLoaded(CLAIMIT_MODID);

--- a/src/main/java/com/github/alexthe666/iceandfire/item/IafItemRegistry.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/IafItemRegistry.java
@@ -253,7 +253,7 @@ public class IafItemRegistry {
 	@GameRegistry.ObjectHolder(IceAndFire.MODID + ":shiny_scales")
 	public static Item shiny_scales = new ItemGeneric("shiny_scales", "iceandfire.shiny_scales");
 	@GameRegistry.ObjectHolder(IceAndFire.MODID + ":earplugs")
-	public static Item earplugs = new ItemModArmor(earplugsArmor, 0, EntityEquipmentSlot.HEAD, "earplugs", "iceandfire.earplugs");
+	public static Item earplugs = new ItemEarplugs();
 	@GameRegistry.ObjectHolder(IceAndFire.MODID + ":hippocampus_fin")
 	public static Item hippocampus_fin = new ItemGeneric("hippocampus_fin", "iceandfire.hippocampus_fin", 1);
 	@GameRegistry.ObjectHolder(IceAndFire.MODID + ":hippocampus_slapper")

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemBlindfold.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemBlindfold.java
@@ -3,6 +3,7 @@ package com.github.alexthe666.iceandfire.item;
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
 import com.github.alexthe666.iceandfire.IceAndFire;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -27,8 +28,14 @@ public class ItemBlindfold extends ItemArmor implements IBauble {
 	}
 
 	@Optional.Method(modid = "baubles")
+	@Override
 	public BaubleType getBaubleType(ItemStack itemStack) {
 		return BaubleType.HEAD;
 	}
 
+	@Optional.Method(modid = "baubles")
+	@Override
+	public void onWornTick(ItemStack itemstack, EntityLivingBase player){
+		player.addPotionEffect(new PotionEffect(MobEffects.BLINDNESS, 20, 2, true, false));
+	}
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemBlindfold.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemBlindfold.java
@@ -1,5 +1,7 @@
 package com.github.alexthe666.iceandfire.item;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
 import com.github.alexthe666.iceandfire.IceAndFire;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
@@ -8,8 +10,10 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
 
-public class ItemBlindfold extends ItemArmor {
+@Optional.Interface(iface = "baubles.api.IBauble", modid = "baubles", striprefs = true)
+public class ItemBlindfold extends ItemArmor implements IBauble {
 
 	public ItemBlindfold() {
 		super(IafItemRegistry.blindfoldArmor, 0, EntityEquipmentSlot.HEAD);
@@ -20,6 +24,11 @@ public class ItemBlindfold extends ItemArmor {
 
 	public void onArmorTick(World world, EntityPlayer player, ItemStack itemStack) {
 		player.addPotionEffect(new PotionEffect(MobEffects.BLINDNESS, 20, 2, true, false));
+	}
+
+	@Optional.Method(modid = "baubles")
+	public BaubleType getBaubleType(ItemStack itemStack) {
+		return BaubleType.HEAD;
 	}
 
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemEarplugs.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemEarplugs.java
@@ -1,0 +1,25 @@
+package com.github.alexthe666.iceandfire.item;
+
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import com.github.alexthe666.iceandfire.IceAndFire;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(iface = "baubles.api.IBauble", modid = "baubles", striprefs = true)
+public class ItemEarplugs extends ItemArmor implements IBauble {
+
+    public ItemEarplugs(){
+        super(IafItemRegistry.earplugsArmor, 0, EntityEquipmentSlot.HEAD);
+        this.setCreativeTab(IceAndFire.TAB_ITEMS);
+        this.setTranslationKey("iceandfire.earplugs");
+        this.setRegistryName(IceAndFire.MODID, "earplugs");
+    }
+
+    @Optional.Method(modid = "baubles")
+    public BaubleType getBaubleType(ItemStack itemStack) {
+        return BaubleType.HEAD;
+    }
+}


### PR DESCRIPTION
Blindfold and Earplugs as Head Slot Bauble. Retains Armor Slot functionality with or without Baubles mod loaded.

Currently missing render when used as baubles

Blacklist QualityTools Quality in `config\qualitytools\Quailities\trinkets.json`
```
    "blacklist": [
      {
        "item": "iceandfire:earplugs"
      },
	  {
        "item": "iceandfire:blindfold"
      }
    ],
```

https://github.com/user-attachments/assets/b92ea0f3-6a8e-470d-ad6f-a3590cb52d23


https://github.com/user-attachments/assets/ec61d3d5-90d6-4aa0-bfe5-3cad8562028d


https://github.com/user-attachments/assets/4f90a3e3-1705-4967-9b77-74dc82f349b3


https://github.com/user-attachments/assets/0f8fb8eb-22fd-4e0e-9c3e-ddd98bbc5978

