### PR TITLE
Added sneak check to dragon bite dismount canceling

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/event/EventLiving.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/event/EventLiving.java
@@ -123,7 +123,7 @@ public class EventLiving {
 		}
 		if (event.getEntityMounting() instanceof  EntityPlayer) {
 			if (event.isDismounting()) {
-				if (!DragonUtils.canDismount(event.getEntityBeingMounted())) {
+				if (!DragonUtils.canDismount(event.getEntityBeingMounted()) && event.getEntityMounting().isSneaking()) {
 					event.setCanceled(true);
 					return;
 				}


### PR DESCRIPTION
Cancels sneak dismount and mounting other entities
Allows recall potion/magic mirror, warpscroll/waystone, ender pear, chorus fruit, and /teleport command.

The current dismount handling breaks how most forms of teleporting work as the above try to dismount the player before calling setPositionAndUpdate to teleport. Since the player is not dismounted, when dragons call updatePreyInMouth, they use setPosition on their bite victim and can teleport them into unloaded chunks.

EntityMountEvent does not provide enough context to filter out the tp cases, however we can change the handling to only apply when Players do sneak dismounting or try mounting another entity.

----------
Current Handling

https://github.com/user-attachments/assets/e36c2676-d74a-450e-a44b-d05fc4bd4c11

https://github.com/user-attachments/assets/fe8ffd49-850e-49f9-9185-9c57bbc9b30f

----------
Only checking sneak dismount and remounting

https://github.com/user-attachments/assets/fabfb227-9bcd-406b-9358-2da03d29b446

https://github.com/user-attachments/assets/16a9c760-848e-4afa-9fd1-bbdd96053737

https://github.com/user-attachments/assets/c7abd1e3-be97-41d8-ba82-e92e26a029c3

https://github.com/user-attachments/assets/d768404d-0832-43ac-9d60-9442e9eaeb60

