### PR TITLE
Some fixes for world gen

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/event/StructureGenerator.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/event/StructureGenerator.java
@@ -108,29 +108,26 @@ public class StructureGenerator implements IWorldGenerator {
 					if (lastMausoleum == null || lastMausoleum.distanceSq(height) >= spawnCheck) {
 						BlockPos surface = world.getHeight(new BlockPos(x, 0, z));
 						surface = degradeSurface(world, surface);
-						new WorldGenMausoleum(EnumFacing.byHorizontalIndex(random.nextInt(3))).generate(world, random, surface);
-						lastMausoleum = surface;
+						if (new WorldGenMausoleum(EnumFacing.byHorizontalIndex(random.nextInt(3))).generate(world, random, surface)) {
+							lastMausoleum = surface;
+						}
 					}
 				}
 			}
 
 			if (IceAndFireConfig.WORLDGEN.generateSirenIslands && random.nextInt(IceAndFireConfig.WORLDGEN.generateSirenChance) == 0 && types.contains(Type.OCEAN) && !isCold && (lastSirenIsland == null || lastSirenIsland.distanceSq(height) >= spawnCheck)) {
-				SIREN_ISLAND.generate(world, random, height);
-				lastSirenIsland = height;
+				if (SIREN_ISLAND.generate(world, random, height)) {
+					lastSirenIsland = height;
+				}
 			}
 
 			if (IceAndFireConfig.WORLDGEN.generateCyclopsCaves && random.nextInt(IceAndFireConfig.WORLDGEN.generateCyclopsChance) == 0 && types.contains(Type.BEACH) && world.getBlockState(height.down()).isOpaqueCube() && (lastCyclopsCave == null || lastCyclopsCave.distanceSq(height) >= spawnCheck)) {
-				CYCLOPS_CAVE.generate(world, random, height);
-				lastCyclopsCave = height;
+				if (CYCLOPS_CAVE.generate(world, random, height)) {
+					lastCyclopsCave = height;
+				}
 			}
 			if (IceAndFireConfig.WORLDGEN.generateWanderingCyclops && BiomeDictionary.hasType(world.getBiome(height), Type.PLAINS) && !isSnowy && !isCold && (lastCyclopsCave == null || lastCyclopsCave.distanceSq(height) >= spawnCheck)) {
-				if (random.nextInt(IceAndFireConfig.WORLDGEN.generateWanderingCyclopsChance + 1) == 0 && !world.getBlockState(height).getMaterial().isLiquid()) {
-					EntityCyclops cyclops = new EntityCyclops(world);
-					cyclops.setPosition(x, height.getY() + 1, z);
-					cyclops.setVariant(random.nextInt(3));
-					if (!world.isRemote) {
-						world.spawnEntity(cyclops);
-					}
+				if (random.nextInt(IceAndFireConfig.WORLDGEN.generateWanderingCyclopsChance) == 0 && !world.getBlockState(height).getMaterial().isLiquid()) {
 					for (int i = 0; i < 3 + random.nextInt(3); i++) {
 						EntitySheep sheep = new EntitySheep(world);
 						sheep.setPosition(x, height.getY() + 1, z);
@@ -139,18 +136,25 @@ public class StructureGenerator implements IWorldGenerator {
 							world.spawnEntity(sheep);
 						}
 					}
-					lastCyclopsCave = height;
+					EntityCyclops cyclops = new EntityCyclops(world);
+					cyclops.setPosition(x, height.getY() + 1, z);
+					cyclops.setVariant(random.nextInt(3));
+					if (!world.isRemote && world.spawnEntity(cyclops)) {
+						lastCyclopsCave = height;
+					}
 				}
 			}
 
 			if (IceAndFireConfig.WORLDGEN.generatePixieVillages && random.nextInt(IceAndFireConfig.WORLDGEN.generatePixieChance) == 0 && types.contains(Type.FOREST) && (types.contains(Type.SPOOKY) || types.contains(Type.MAGICAL)) && (lastPixieVillage == null || lastPixieVillage.distanceSq(height) >= spawnCheck)) {
-				PIXIE_VILLAGE.generate(world, random, height);
-				lastPixieVillage = height;
+				if (PIXIE_VILLAGE.generate(world, random, height)) {
+					lastPixieVillage = height;
+				}
 			}
 
 			if (IceAndFireConfig.WORLDGEN.generateHydraCaves && random.nextInt(IceAndFireConfig.WORLDGEN.generateHydrasChance) == 0 && types.contains(Type.SWAMP) && world.getBlockState(height.down()).isOpaqueCube() && (lastHydraCave == null || lastHydraCave.distanceSq(height) >= spawnCheck)) {
-				HYDRA_CAVE.generate(world, random, height);
-				lastHydraCave = height;
+				if (HYDRA_CAVE.generate(world, random, height)) {
+					lastHydraCave = height;
+				}
 			}
 
 			if ((IceAndFireConfig.WORLDGEN.generateDragonRoosts || IceAndFireConfig.WORLDGEN.generateDragonDens) && isDragonGenAllowedInDim(world.provider.getDimension()) && isDragonGenAllowedInBiome(types, biomeName) && (lastDragonRoost == null || lastDragonRoost.distanceSq(height) >= spawnCheck)) {
@@ -246,15 +250,17 @@ public class StructureGenerator implements IWorldGenerator {
 			if (IceAndFireConfig.WORLDGEN.generateMyrmexColonies && isMyrmexGenAllowedInBiome(types, biomeName) && random.nextInt(IceAndFireConfig.WORLDGEN.myrmexColonyGenChance) == 0 && (types.contains(Type.JUNGLE) || types.contains(Type.HOT) && types.contains(Type.DRY) && types.contains(Type.SANDY)) && MyrmexWorldData.get(world).getNearestHive(height, 500) == null && (lastMyrmexHive == null || lastMyrmexHive.distanceSq(height) >= spawnCheck)) {
 				BlockPos lowestHeight = new BlockPos(height.getX(), world.getChunksLowestHorizon(height.getX(), height.getZ()), height.getZ());
 				int down = Math.max(15, lowestHeight.getY() - 20 + random.nextInt(10));
-				if (types.contains(Type.JUNGLE)) JUNGLE_MYRMEX_HIVE.generate(world, random, new BlockPos(lowestHeight.getX(), down, lowestHeight.getZ()));
-				else DESERT_MYRMEX_HIVE.generate(world, random, new BlockPos(lowestHeight.getX(), down, lowestHeight.getZ()));
-				lastMyrmexHive = height;
+				WorldGenMyrmexHive myrmexHive = types.contains(Type.JUNGLE) ? JUNGLE_MYRMEX_HIVE : DESERT_MYRMEX_HIVE;
+				if (myrmexHive.generate(world, random, new BlockPos(lowestHeight.getX(), down, lowestHeight.getZ()))) {
+					lastMyrmexHive = height;
+				}
 			}
 		}
 
 		if (IceAndFireConfig.WORLDGEN.generateSnowVillages && isVillageGenAllowedInDim(world.provider.getDimension()) && isCold && isSnowy && (lastSnowVillage == null || lastSnowVillage.distanceSq(height) >= spawnCheck)) {
-			SNOW_VILLAGE.generate(world, random, height);
-			lastSnowVillage = height;
+			if (SNOW_VILLAGE.generate(world, random, height)) {
+				lastSnowVillage = height;
+			}
 		}
 
 		if (IceAndFireConfig.ENTITY_SPAWNING.spawnHippocampus && random.nextInt(IceAndFireConfig.ENTITY_SPAWNING.hippocampusSpawnChance) == 0 && types.contains(Type.OCEAN)) {

--- a/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenMyrmexHive.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenMyrmexHive.java
@@ -44,7 +44,7 @@ public class WorldGenMyrmexHive extends WorldGenerator {
         BlockPos undergroundPos = new BlockPos(position.getX(), position.getY(), position.getZ());
         entrances = 0;
         generateHive(worldIn, rand, undergroundPos);
-        return false;
+        return true;
     }
 
     public void generateForQueen(EntityMyrmexQueen queen, Random rand, BlockPos position) {

--- a/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenSirenIsland.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenSirenIsland.java
@@ -43,7 +43,7 @@ public class WorldGenSirenIsland extends WorldGenerator {
                 }
             }
         }
-        return false;
+        return layer > 1;
     }
 
     private int getRadius(int layer, int up){

--- a/src/main/java/com/github/alexthe666/iceandfire/world/village/MapGenSnowVillage.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/village/MapGenSnowVillage.java
@@ -45,12 +45,12 @@ public class MapGenSnowVillage extends WorldGenerator {
 	@Override
 	public boolean generate(World world, Random rand, BlockPos position) {
 		this.distance = 9;
-		boolean canSpawn = canSpawnStructureAtCoords(world, position.getX() >> 4, position.getZ() >> 4);
-		if (new Random().nextInt(IceAndFireConfig.WORLDGEN.generateSnowVillageChance + 1) == 0) {
+		if (new Random().nextInt(IceAndFireConfig.WORLDGEN.generateSnowVillageChance) == 0) {
 			int new_size = 32;
 			getStructureStart(world, position.getX() >> 4, position.getZ() >> 4, rand).generateStructure(world, rand, new StructureBoundingBox(position.getX() - new_size, position.getZ() - new_size, position.getX() + new_size, position.getZ() + new_size));
+			return true;
 		}
-		return canSpawn;
+		return false;
 	}
 
 	public String getStructureName() {


### PR DESCRIPTION
https://github.com/kotlin-programmer/Ice_and_Fire_RLCraft/commit/0719dbe5965c639f460697ebcb55a9722c8c4807 made Snow Villages drastically rarer due to accidentally checking failed generation positions.

Fixed
-----
* Snow Village minimum distance checking failed positions
* Snow Village gen chance "off by one n"
* Wandering Cyclops gen chance "off by one n"
* Made clear that every WorldGenerator must succeed in order to set a valid position for minimum distance checks

Observation of Multithreading
-----
World Gen is multi-threaded and so the "World Gen Minimum Distance" config is not always producing results as expected. This is noticeable with extremely high gen chances, though the config option will still lower the quantity compared to no minimum distance.

<img width="1280" height="720" alt="2025-12-27_22 09 42" src="https://github.com/user-attachments/assets/442e192f-18ea-4e33-bb9c-02ed9252e9f5" />

> Example Dragon Roost Chance of 1/10 with a "World Gen Minimum Distance" of 300.